### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Manage your GoLogin browser profiles and automation directly through AI conversations. This MCP server connects to the GoLogin API, letting you create, configure, and control browser profiles using natural language.
 
+<a href="https://glama.ai/mcp/servers/@gologinapp/gologin-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gologinapp/gologin-mcp/badge" alt="GoLogin MCP server" />
+</a>
+
 ## What You Can Do
 
 With GoLogin MCP Server, you can:


### PR DESCRIPTION
This PR adds a badge for the [GoLogin MCP](https://glama.ai/mcp/servers/@gologinapp/gologin-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gologinapp/gologin-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gologinapp/gologin-mcp/badge" alt="GoLogin MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.